### PR TITLE
Enabled external customization of configure.ac and fixed for building

### DIFF
--- a/.github/workflows/ostypevars.sh
+++ b/.github/workflows/ostypevars.sh
@@ -146,6 +146,11 @@ elif [ "X${CI_OSTYPE}" = "Xcentos:8" ] || [ "X${CI_OSTYPE}" = "Xcentos:centos8" 
 	PKG_EXT="rpm"
 	IS_OS_CENTOS=1
 
+	#
+	# Change mirrorlist
+	#
+	sed -i -e 's|^mirrorlist|#mirrorlist|g' -e 's|^#baseurl=http://mirror|baseurl=http://vault|g' /etc/yum.repos.d/CentOS-*repo
+
 	# [NOTE]
 	# Since it is difficult to install ShellCheck on CentOS8, it will not be installed.
 	#

--- a/Makefile.am
+++ b/Makefile.am
@@ -22,7 +22,12 @@ SUBDIRS = src buildutils test
 
 ACLOCAL_AMFLAGS = -I m4
 
-EXTRA_DIST = RELEASE_VERSION
+EXTRA_DIST = RELEASE_VERSION @CONFIGURECUSTOM@
+
+# [NOTE]
+# Change the default target to build.
+#
+.DEFAULT_GOAL := build
 
 # [CLEAN]
 # Use clean-local instead of CLEANFILES as it contains subdirectories and so on.

--- a/buildutils/make_rpm_changelog.sh
+++ b/buildutils/make_rpm_changelog.sh
@@ -82,6 +82,7 @@ DETAILS=""
 ALLLINES=""
 SET_FIRST_VERSION=0
 while read -r oneline; do
+	# shellcheck disable=SC2269
 	oneline="${oneline}"
 	if [ "X${oneline}" = "X" ]; then
 		continue
@@ -99,8 +100,7 @@ while read -r oneline; do
 		fi
 	else
 		TEST_CONTENTS=$(echo "${oneline}" | grep '^[-][-].*[ ][ ].*$')
-		PKG_RF2822=$(echo "${TEST_CONTENTS}" | grep -o '[ ][ ].*')
-		PKG_RF2822="${PKG_RF2822}"
+		PKG_RF2822="$(echo "${TEST_CONTENTS}" | grep -o '[ ][ ].*')"
 		PKG_COMMITTER=$(echo "${TEST_CONTENTS}" | grep -o '.*[ ][ ]' | sed 's/^[-][-][ ]//')
 		if [ "X${PKG_RF2822}" != "X" ] && [ "X${PKG_COMMITTER}" != "X" ]; then
 			INONEVER=0
@@ -125,7 +125,7 @@ done < "${CHANGELOG_FILE}"
 #
 # NOTE: echo command on ubuntu is print '-e', we need to cut it.
 #
-# shellcheck disable=SC2039
+# shellcheck disable=SC2039,SC3037
 echo -e "${ALLLINES}" | sed 's/^-e //g'
 
 exit 0

--- a/configure.ac
+++ b/configure.ac
@@ -34,14 +34,39 @@ AC_PROG_LN_S
 AC_PROG_MAKE_SET
 
 #
+# Load customizable variables
+#
+AC_CHECK_FILE([configure.custom],
+	[
+		configure_custom_file="configure.custom"
+		custom_git_domain="$(grep '^\s*GIT_DOMAIN\s*=' configure.custom | sed -e 's|^\s*GIT_DOMAIN\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+		custom_git_org="$(grep '^\s*GIT_ORG\s*=' configure.custom | sed -e 's|^\s*GIT_ORG\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+		custom_git_repo="$(grep '^\s*GIT_REPO\s*=' configure.custom | sed -e 's|^\s*GIT_REPO\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+		custom_git_endpoint="$(grep '^\s*GIT_EP_V3_REPO\s*=' configure.custom | sed -e 's|^\s*GIT_EP_V3_REPO\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+		custom_dev_email="$(grep '^\s*DEV_EMAIL\s*=' configure.custom | sed -e 's|^\s*DEV_EMAIL\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+		custom_dev_name="$(grep '^\s*DEB_NAME\s*=' configure.custom | sed -e 's|^\s*DEB_NAME\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+	],
+	[
+		configure_custom_file=""
+		custom_git_domain="github.com"
+		custom_git_org="yahoojapan"
+		custom_git_repo="k2hdkc_dbaas_cli"
+		custom_git_endpoint="https://api.github.com/repos/"
+		custom_dev_email="antpickax-support@mail.yahoo.co.jp"
+		custom_dev_name="K2HR3_DEVELOPER"
+	]
+)
+
+#
 # Symbols for buildutils
 #
-AC_SUBST([GIT_DOMAIN], "github.com")
-AC_SUBST([GIT_ORG], "yahoojapan")
-AC_SUBST([GIT_REPO], "k2hdkc_dbaas_cli")
-AC_SUBST([DEV_EMAIL], "`echo ${DEBEMAIL:-antpickax-support@mail.yahoo.co.jp}`")
-AC_SUBST([DEV_NAME], "`echo ${DEBFULLNAME:-K2HR3_DEVELOPER}`")
-
+AC_SUBST([CONFIGURECUSTOM], "${configure_custom_file}")
+AC_SUBST([GIT_DOMAIN], "${custom_git_domain}")
+AC_SUBST([GIT_ORG], "${custom_git_org}")
+AC_SUBST([GIT_REPO], "${custom_git_repo}")
+AC_SUBST([DEV_EMAIL], "$(echo ${DEBEMAIL:-"${custom_dev_email}"})")
+AC_SUBST([DEV_NAME], "$(echo ${DEBFULLNAME:-"${custom_dev_name}"})")
+#
 AC_SUBST([RPMCHANGELOG], "`$(pwd)/buildutils/make_rpm_changelog.sh $(pwd)/ChangeLog`")
 AC_SUBST([SHORTDESC], "K2HDKC DBaaS Command Line Interface(K2HR3 CLI Plugin)")
 AC_SUBST([PKG_VERSION], "`$(pwd)/buildutils/make_variables.sh -pkg_version`")

--- a/test/test.sh
+++ b/test/test.sh
@@ -72,7 +72,7 @@ TEST_FILES=""
 for _TEST_FILE_TMP in "${TESTDIR}"/*; do
 	_TEST_FILE_TMP=$(pecho -n "${_TEST_FILE_TMP}" | sed "s#^${TESTDIR}/##g")
 	case ${_TEST_FILE_TMP} in
-		${TESTMAINBIN})
+		"${TESTMAINBIN}")
 			;;
 		test_*.sh)
 			if [ "X${TEST_FILES}" = "X" ]; then


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
- Enabled to customize variables in configure.ac  
If the configure.custom file exists, it will be loaded.  
(currently unused but added to increase availability)
- Fixed CentOS 8 build failing.  
It was caused by changing the mirror, so I fixed it.
- Fixed shellcheck errors

