### PR TITLE
Updated k2hdkc_dbaas_resource.templ for data directory path changed

### DIFF
--- a/src/libexec/database/k2hdkc_dbaas_resource.templ
+++ b/src/libexec/database/k2hdkc_dbaas_resource.templ
@@ -112,7 +112,7 @@ SSL                 = no
 #
 [K2HDKC]
 K2HTYPE             = file
-K2HFILE             = /var/lib/k2hdkc/data/k2hdkc.k2h
+K2HFILE             = /var/lib/antpickax/k2hdkc/data/k2hdkc.k2h
 K2HFULLMAP          = on
 K2HINIT             = no
 K2HMASKBIT          = 8


### PR DESCRIPTION
### Relevant Issues/Pull Requests (if applicable)
n/a

### Details
The `/var/lib/k2hdkc/data` path has been changed to `/var/lib/antpickax/k2hdkc`.
